### PR TITLE
Rename `uneffectfulHref` to `hrefPure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Rename `uneffectfulHref` to `hrefPure` (used in `Show` instance) (#21 by @JordanMartinez)
 
 ## [v7.0.0](https://github.com/purescript-node/purescript-node-url/releases/tag/v7.0.0) - 2023-07-31
 

--- a/src/Node/URL.js
+++ b/src/Node/URL.js
@@ -15,7 +15,7 @@ export const hostnameImpl = (u) => u.hostname;
 export const setHostnameImpl = (val, u) => {
   u.hostname = val;
 };
-export const uneffectfulHref = (u) => u.href;
+export const hrefPure = (u) => u.href;
 export const hrefImpl = (u) => u.href;
 export const setHrefImpl = (val, u) => {
   u.href = val;

--- a/src/Node/URL.purs
+++ b/src/Node/URL.purs
@@ -49,7 +49,7 @@ import Prim.Row as Row
 foreign import data URL :: Type
 
 instance Show URL where
-  show x = "URL(" <> uneffectfulHref x <> ")"
+  show x = "URL(" <> hrefPure x <> ")"
 
 new :: String -> Effect URL
 new input = runEffectFn1 newImpl input
@@ -96,7 +96,8 @@ setHostname val url = runEffectFn2 setHostnameImpl val url
 
 foreign import setHostnameImpl :: EffectFn2 String URL Unit
 
-foreign import uneffectfulHref :: URL -> String
+-- do not export
+foreign import hrefPure :: URL -> String
 
 href :: URL -> Effect String
 href url = runEffectFn1 hrefImpl url


### PR DESCRIPTION
**Description of the change**

Implements the change suggested in https://github.com/purescript-node/purescript-node-url/pull/20#discussion_r1280062122. Since this is an internal implementation detail, I'll put this in unreleased and leave it as that for now. When a new release is made later, it'll be renamed in that new release.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
